### PR TITLE
 Add Whitelisting Features to allow some external conntections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # misp-guard
 `misp-guard` is a [mitmproxy](https://mitmproxy.org/) addon that inspects the synchronization traffic (via `PUSH` or `PULL`) between different MISP instances and applies a set of customizable rules defined in a JSON file.
 
-> **NOTE: By default this addon will block all outgoing HTTP requests that are not required during a MISP server sync.**
+> **NOTE: By default this addon will block all outgoing HTTP requests that are not required during a MISP server sync. However, individual URLs or domains can be whitelisted if necessary.**
 
 ## PUSH
 ```mermaid
@@ -93,6 +93,12 @@ sequenceDiagram
 * `blocked_attribute_types`: Blocks if the event contains an attribute matching one of this types.
 * `blocked_attribute_categories`: Blocks if the event contains an attribute matching one of this categories.
 * `blocked_object_types`: Blocks if the event contains an object matching one of this types.
+
+**Whitelisting**
+
+* To whitelist individual URLs or domains, simply add them as a JSON array under the " whitelisting" element.
+  * `urls` The entire URL is checked and only exact calls are allowed.
+  * `domains` In contrast, only the domain is checked and any website behind the domain can be queried. Should only be used if static whitelisting of individual URLs is not possible.
 
 See sample config [here](src/test/test_config.json).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # misp-guard
 `misp-guard` is a [mitmproxy](https://mitmproxy.org/) addon that inspects the synchronization traffic (via `PUSH` or `PULL`) between different MISP instances and applies a set of customizable rules defined in a JSON file.
 
-> **NOTE: By default this addon will block all outgoing HTTP requests that are not required during a MISP server sync. However, individual URLs or domains can be whitelisted if necessary.**
+> **NOTE: By default this addon will block all outgoing HTTP requests that are not required during a MISP server sync. However, individual URLs or domains can be allowed if necessary.**
 
 ## PUSH
 ```mermaid
@@ -94,11 +94,11 @@ sequenceDiagram
 * `blocked_attribute_categories`: Blocks if the event contains an attribute matching one of this categories.
 * `blocked_object_types`: Blocks if the event contains an object matching one of this types.
 
-**Whitelisting**
+**Allowlist**
 
-* To whitelist individual URLs or domains, simply add them as a JSON array under the " whitelisting" element.
+* To allow individual URLs or domains, simply add them as a JSON array under the `allowlist` element.
   * `urls` The entire URL is checked and only exact calls are allowed.
-  * `domains` In contrast, only the domain is checked and any website behind the domain can be queried. Should only be used if static whitelisting of individual URLs is not possible.
+  * `domains` In contrast, only the domain is checked and any website behind the domain can be queried. Should only be used if adding exact URLs is not possible.
 
 See sample config [here](src/test/test_config.json).
 

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -2,6 +2,25 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
+        "whitelisting": {
+            "type": "object",
+            "properties": {
+                "urls": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "url"
+                    }
+                },
+                "domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "domain"
+                    }
+                }
+            }
+        },
         "compartments_rules": {
             "type": "object",
             "properties": {

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
-        "whitelisting": {
+        "allowlist": {
             "type": "object",
             "properties": {
                 "urls": {

--- a/src/mispguard.py
+++ b/src/mispguard.py
@@ -128,7 +128,7 @@ class MispGuard:
         loader.add_option("config", str, "", "MISP Guard configuration file")
 
     def request(self, flow: http.HTTPFlow) -> None:
-        if (not (self.url_is_whitelisted(flow) or self.domain_is_whitelisted(flow))) :
+        if (not (self.url_is_allowed(flow) or self.domain_is_allowed(flow))) :
             try:  
                 flow = self.enrich_flow(flow)
                 if self.can_reach_compartment(flow) and self.is_allowed_endpoint(flow.request.method, flow.request.path):
@@ -146,7 +146,7 @@ class MispGuard:
         else:
             try:  
                 if self.src_instance_is_allowed(flow):
-                    logger.info("request from whitelisted url - skipping further processing")
+                    logger.info("request from allowed url - skipping further processing")
             except ForbiddenException as ex:
                 logger.error(ex)
                 return self.forbidden(flow, str(ex))
@@ -156,7 +156,7 @@ class MispGuard:
             
 
     def response(self,  flow: http.HTTPFlow) -> None:
-        if (not (self.url_is_whitelisted(flow) or self.domain_is_whitelisted(flow))):
+        if (not (self.url_is_allowed(flow) or self.domain_is_allowed(flow))):
             try:
                 flow = self.enrich_flow(flow)
                 if self.can_reach_compartment(flow):
@@ -170,7 +170,7 @@ class MispGuard:
         else:
             try:
                 if  self.src_instance_is_allowed(flow):
-                    logger.info("response from whitelisted url - skipping further processing")
+                    logger.info("response from allowed url - skipping further processing")
             except ForbiddenException as ex:
                 logger.error(ex)
                 return self.forbidden(flow, str(ex))
@@ -179,14 +179,14 @@ class MispGuard:
                 return self.forbidden(flow, "unexpected error, rejecting response")
             
     
-    def url_is_whitelisted(self, flow: http.HTTPFlow) -> bool:
-        if flow.request.url in self.config["whitelisting"]["urls"]:
+    def url_is_allowed(self, flow: http.HTTPFlow) -> bool:
+        if flow.request.url in self.config["allowlist"]["urls"]:
             return True
         else:
             return False
     
-    def domain_is_whitelisted(self, flow: http.HTTPFlow) -> bool:
-        if flow.request.host in self.config["whitelisting"]["domains"]:
+    def domain_is_allowed(self, flow: http.HTTPFlow) -> bool:
+        if flow.request.host in self.config["allowlist"]["domains"]:
             return True
         else:
             return False

--- a/src/test/test_config.json
+++ b/src/test/test_config.json
@@ -1,5 +1,5 @@
 {
-    "whitelisting": {
+    "allowlist": {
         "urls":  [
                 "http://www.dan.me.uk:443/torlist/?exit"
         ],

--- a/src/test/test_config.json
+++ b/src/test/test_config.json
@@ -1,4 +1,12 @@
 {
+    "whitelisting": {
+        "urls":  [
+                "http://www.dan.me.uk:443/torlist/?exit"
+        ],
+        "domains": [
+            "snort-org-site.s3.amazonaws.com"
+        ]
+    },
     "compartments_rules": {
         "can_reach": {
             "compartment_1": [

--- a/src/test/test_misp_guard.py
+++ b/src/test/test_misp_guard.py
@@ -78,7 +78,7 @@ class TestMispGuard:
         assert flow.response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_whitelisted_domain_from_unknown_src_is_blocked(self, caplog):
+    async def test_allowed_domain_from_unknown_src_is_blocked(self, caplog):
         caplog.set_level("INFO")
         mispguard = self.load_mispguard()
         test_path="/torlist/?exit"
@@ -101,7 +101,7 @@ class TestMispGuard:
 
 
     @pytest.mark.asyncio
-    async def test_whitelisted_domain_from_known_src_is_allowed(self, caplog):
+    async def test_allowed_domain_from_known_src_is_allowed(self, caplog):
         caplog.set_level("INFO")
         mispguard = self.load_mispguard()
 
@@ -122,13 +122,13 @@ class TestMispGuard:
         mispguard.response(flow)
 
         assert "MispGuard initialized" in caplog.text
-        assert "request from whitelisted url - skipping further processing" in caplog.text
-        assert "response from whitelisted url - skipping further processing" in caplog.text
+        assert "request from allowed url - skipping further processing" in caplog.text
+        assert "response from allowed url - skipping further processing" in caplog.text
         assert flow.response.status_code == 200
 
 
     @pytest.mark.asyncio
-    async def test_whitelisted_url_from_unknown_src_is_blocked(self, caplog):
+    async def test_allowed_url_from_unknown_src_is_blocked(self, caplog):
         caplog.set_level("INFO")
         mispguard = self.load_mispguard()
         test_path="/torlist/?exit"
@@ -151,7 +151,7 @@ class TestMispGuard:
 
 
     @pytest.mark.asyncio
-    async def test_whitelisted_url_from_known_src_is_allowed(self, caplog):
+    async def test_allowed_url_from_known_src_is_allowed(self, caplog):
         caplog.set_level("INFO")
         mispguard = self.load_mispguard()
 
@@ -172,8 +172,8 @@ class TestMispGuard:
         mispguard.response(flow)
 
         assert "MispGuard initialized" in caplog.text
-        assert "request from whitelisted url - skipping further processing" in caplog.text
-        assert "response from whitelisted url - skipping further processing" in caplog.text
+        assert "request from allowed url - skipping further processing" in caplog.text
+        assert "response from allowed url - skipping further processing" in caplog.text
         assert flow.response.status_code == 200
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Dear MISP-Guard maintainers,

I would like to submit a pull request addressing the need to allow external MISP feed connections while maintaining MISP-Guard's security posture.

### Motivation

MISP-Guard currently blocks all connections to and from unknown sources by default, which is an important security measure. However, many users rely on external MISP feeds to improve their threat intelligence. Therefore, it should be possible to whitelist URLs and domains so that feeds and MISPGuard can be used at the same time.

### Proposed Changes

I have added a new feature to MISP-Guard that allows users to define a whitelist of trusted external MISP feed URLs and domains. Any connection request from a server configured in `instances_host_mapping` to one of the entries in this whitelist will be allowed, while connections from unknown sources will still be blocked.

#### The changes include:

  1. Configuration Option: Added a new configuration option in the config.schema.json file to specify a list of trusted external `urls` and `domains`.  With the help of json arrays, users can add their MISP-Feeds to this list for whitelisting.
  2. Enhanced testing: The test suite has been extended to thoroughly cover the new whitelisting feature. Extended `pytest` suite to ensure correctness and security of changes.
  3. Documentation: Updated the project documentation to explain how to configure and use the new whitelisting feature effectively.

### Conclusion

I believe this feature will enhance the usability of MISP-Guard for users who rely on external MISP feeds. It strikes a balance between security and flexibility, allowing connections to known and trusted sources while maintaining the default security level.

I look forward to your feedback and am open to making any necessary adjustments based on your review. Thanks for considering this pull request.

Sincerely,
sva-mk
